### PR TITLE
Capture just the content of a component

### DIFF
--- a/docker/cypress/integration/main.spec.js
+++ b/docker/cypress/integration/main.spec.js
@@ -18,6 +18,18 @@ describe('Visual Regression Example', () => {
     cy.compareSnapshot('login', 0.1);
   });
 
+  it('should display the component correctly', () => {
+    if (Cypress.env('type') === 'base') {
+      cy.visit('/03.html');
+      cy.get('H1').contains('Login');
+      cy.get('form').compareSnapshot('login-form');
+    } else {
+      cy.visit('/03.html');
+      cy.get('H1').contains('Login');
+      cy.get('form').compareSnapshotTest('login-form').should('be.true');
+    }
+  });
+
   it('should display the foo page incorrectly', () => {
     if (Cypress.env('type') === 'base') {
       cy.visit('/04.html');

--- a/docker/cypress/support/commands.js
+++ b/docker/cypress/support/commands.js
@@ -1,28 +1,32 @@
 const compareSnapshotCommand = require('../../dist/command.js');
 
 function compareSnapshotTestCommand() {
-  Cypress.Commands.add('compareSnapshotTest', (name, errorThreshold = 0.00) => {
+  Cypress.Commands.add('compareSnapshotTest', { prevSubject: 'optional' }, (subject, name, errorThreshold = 0.00) => {
     // get image title from the 'type' environment variable
     let title = 'actual';
-    if (Cypress.env('type') === 'base') {
-      title = 'base';
-    }
+    if(Cypress.env('type') === 'base') {
+    title = 'base';
+  }
 
-    // take snapshot
+  // take snapshot
+  if (subject) {
+    cy.get(subject).screenshot(`${name}-${title}`);
+  } else {
     cy.screenshot(`${name}-${title}`);
+  }
 
-    // run visual tests
-    if (Cypress.env('type') === 'actual') {
-      const options = {
-        fileName: name,
-        specDirectory: Cypress.spec.name
-      };
-      cy.task('compareSnapshotsPlugin', options).then(results => {
-        if (results.percentage > errorThreshold) return false;
-        return true;
-      });
-    }
-  });
+  // run visual tests
+  if (Cypress.env('type') === 'actual') {
+    const options = {
+      fileName: name,
+      specDirectory: Cypress.spec.name
+    };
+    cy.task('compareSnapshotsPlugin', options).then(results => {
+      if (results.percentage > errorThreshold) return false;
+      return true;
+    });
+  }
+});
 }
 
 compareSnapshotTestCommand();

--- a/src/command.js
+++ b/src/command.js
@@ -1,15 +1,18 @@
 /* eslint-disable no-undef */
 
 function compareSnapshotCommand() {
-  Cypress.Commands.add('compareSnapshot', (name, errorThreshold = 0.0) => {
-    // get image title from the 'type' environment variable
+  Cypress.Commands.add('compareSnapshot', { prevSubject: 'optional' }, (subject, name, errorThreshold = 0.0) => {
     let title = 'actual';
     if (Cypress.env('type') === 'base') {
       title = 'base';
     }
 
     // take snapshot
-    cy.screenshot(`${name}-${title}`);
+    if (subject) {
+      cy.get(subject).screenshot(`${name}-${title}`);
+    } else {
+      cy.screenshot(`${name}-${title}`);
+    }
 
     // run visual tests
     if (Cypress.env('type') === 'actual') {

--- a/src/command.js
+++ b/src/command.js
@@ -1,32 +1,36 @@
 /* eslint-disable no-undef */
 
 function compareSnapshotCommand() {
-  Cypress.Commands.add('compareSnapshot', { prevSubject: 'optional' }, (subject, name, errorThreshold = 0.0) => {
-    let title = 'actual';
-    if (Cypress.env('type') === 'base') {
-      title = 'base';
-    }
+  Cypress.Commands.add(
+    'compareSnapshot',
+    { prevSubject: 'optional' },
+    (subject, name, errorThreshold = 0.0) => {
+      let title = 'actual';
+      if (Cypress.env('type') === 'base') {
+        title = 'base';
+      }
 
-    // take snapshot
-    if (subject) {
-      cy.get(subject).screenshot(`${name}-${title}`);
-    } else {
-      cy.screenshot(`${name}-${title}`);
-    }
+      // take snapshot
+      if (subject) {
+        cy.get(subject).screenshot(`${name}-${title}`);
+      } else {
+        cy.screenshot(`${name}-${title}`);
+      }
 
-    // run visual tests
-    if (Cypress.env('type') === 'actual') {
-      const options = {
-        fileName: name,
-        specDirectory: Cypress.spec.name,
-      };
-      cy.task('compareSnapshotsPlugin', options).then((results) => {
-        if (results.percentage > errorThreshold) {
-          throw new Error(`${name} images are different`);
-        }
-      });
+      // run visual tests
+      if (Cypress.env('type') === 'actual') {
+        const options = {
+          fileName: name,
+          specDirectory: Cypress.spec.name,
+        };
+        cy.task('compareSnapshotsPlugin', options).then((results) => {
+          if (results.percentage > errorThreshold) {
+            throw new Error(`${name} images are different`);
+          }
+        });
+      }
     }
-  });
+  );
 }
 
 /* eslint-enable no-undef */


### PR DESCRIPTION
This tweaks the`compareSnapshot` command adding the ability to capture/compare only the content of a single component.

```javascript
// new feature: usage on a subject
cy.get('#my-header').compareSnapshot('just-header')

// still supported
cy.compareSnapshot('whole-page')
```