### PR TITLE
Run build on install from a git branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-visual-regression",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "lint": "./node_modules/.bin/eslint src/**",
     "prebuild": "./node_modules/.bin/rimraf dist",
     "build": "./node_modules/.bin/babel src --out-dir dist",
+    "prepare": "npm run build",
     "ci": "export SNAPSHOT_DIRECTORY=cypress/snapshots && npm run build && npm run base && npm test",
-    "prettier:check": "prettier --check --trailing-comma es5 --single-quote --arrow-parens always 'src/**/*.js'",
-    "prettier:fix": "prettier --write --trailing-comma es5 --single-quote --arrow-parens always 'src/**/*.js'"
+    "prettier:check": "prettier --check --trailing-comma es5 --single-quote --arrow-parens always \"src/**/*.js\"",
+    "prettier:fix": "prettier --write --trailing-comma es5 --single-quote --arrow-parens always \"src/**/*.js\""
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Add prepare script to run build step.
Fix quoting prettier commands for windows.

We tried installing the `npm i` from github  in order to test #25, but that doesn't create a `dist` folder, because `build` is not run. The correct step for this is to run `prepare` initially. 
https://blog.jim-nielsen.com/2018/installing-and-building-an-npm-package-from-github/