### PR TITLE
Adding possibility to pass options to cy.screenshot

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
     "extends": [
       "airbnb-base",
       "prettier"
-    ]
+    ],
+    "rules": {
+      "prefer-object-spread": 0
+    }
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ const compareSnapshotCommand = require('cypress-visual-regression/dist/command')
 compareSnapshotCommand();
 ```
 
+Optionally you can pass default `cy.screenshot()` parameters, these will be use in case no parameters are passed for `compareSnapshot` command:
+
+```javascript
+const compareSnapshotCommand = require('cypress-visual-regression/dist/command');
+
+compareSnapshotCommand({
+  capture: 'fullPage'
+});
+```
+
 ## To Use
 
 Add `cy.compareSnapshot('home');` in your tests specs whenever you want to test for visual regressions, making sure to replace `home` with a relevant name. You can also add an optional error threshold: Value can range from 0.00 (no difference) to 1.00 (every pixel is different). So, if you enter an error threshold of 0.51, the test would fail only if > 51% of pixels are different.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ You can target a single HTML element as well:
 cy.get('#my-header').compareSnapshot('just-header')
 ```
 
+You can pass arguments to `cy.screenshot()` as well, in that case the error threshold can be passed as `errorThreshold` property of object:
+
+```js
+it('should display the login page correctly', () => {
+  cy.visit('/03.html');
+  cy.compareSnapshot('login', {
+    capture: 'fullPage',
+    errorThreshold: 0.1
+  });
+});
+```
 > Looking for more examples? Review [docker/cypress/integration/main.spec.js](https://github.com/mjhea0/cypress-visual-regression/blob/master/docker/cypress/integration/main.spec.js).
 
 

--- a/docker/cypress/integration/main.spec.js
+++ b/docker/cypress/integration/main.spec.js
@@ -74,4 +74,11 @@ describe('Visual Regression Example', () => {
       cy.compareSnapshotTest('bar').should('be.false');
     }
   });
+
+  it("should pass parameters to cy.screenshot", () => {
+    cy.visit("/08.html");
+    cy.compareSnapshot("screenshot-params-full", {
+      capture: "fullPage"
+    });
+  });
 });

--- a/docker/cypress/support/commands.js
+++ b/docker/cypress/support/commands.js
@@ -1,7 +1,16 @@
 const compareSnapshotCommand = require('../../dist/command.js');
 
 function compareSnapshotTestCommand() {
-  Cypress.Commands.add('compareSnapshotTest', { prevSubject: 'optional' }, (subject, name, errorThreshold = 0.00) => {
+  Cypress.Commands.add('compareSnapshotTest', { prevSubject: 'optional' }, (subject, name, params = 0.0) => {
+    let screenshotOptions = {};
+    let errorThreshold = 0.0;
+    if (typeof params === 'number') {
+      errorThreshold = params;
+    } else if (typeof params === 'object') {
+      errorThreshold = params.errorThreshold || 0.0;
+      // eslint-disable-next-line prefer-object-spread
+      screenshotOptions = Object.assign({}, params);
+    }
     // get image title from the 'type' environment variable
     let title = 'actual';
     if (Cypress.env('type') === 'base') {
@@ -10,9 +19,9 @@ function compareSnapshotTestCommand() {
 
     // take snapshot
     if (subject) {
-      cy.get(subject).screenshot(`${name}-${title}`);
+      cy.get(subject).screenshot(`${name}-${title}`, screenshotOptions);
     } else {
-      cy.screenshot(`${name}-${title}`);
+      cy.screenshot(`${name}-${title}`, screenshotOptions);
     }
 
     // run visual tests

--- a/docker/web/08.html
+++ b/docker/web/08.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Base</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div class="container">
+      <h1 style="color: purple">Color</h1>
+      <div style="height: 1900px; background-color: darkgray">Long</div>
+    </div>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-visual-regression",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/command.js
+++ b/src/command.js
@@ -1,10 +1,18 @@
 /* eslint-disable no-undef */
 
-function compareSnapshotCommand() {
+function compareSnapshotCommand(defaultScreenshotOptions) {
   Cypress.Commands.add(
     'compareSnapshot',
     { prevSubject: 'optional' },
-    (subject, name, errorThreshold = 0.0) => {
+    (subject, name, params = 0.0) => {
+      let screenshotOptions = defaultScreenshotOptions;
+      let errorThreshold = 0.0;
+      if (typeof params === 'number') {
+        errorThreshold = params;
+      } else if (typeof params === 'object') {
+        errorThreshold = params.errorThreshold || 0.0;
+        screenshotOptions = { ...screenshotOptions, ...params };
+      }
       let title = 'actual';
       if (Cypress.env('type') === 'base') {
         title = 'base';
@@ -12,9 +20,9 @@ function compareSnapshotCommand() {
 
       // take snapshot
       if (subject) {
-        cy.get(subject).screenshot(`${name}-${title}`);
+        cy.get(subject).screenshot(`${name}-${title}`, screenshotOptions);
       } else {
-        cy.screenshot(`${name}-${title}`);
+        cy.screenshot(`${name}-${title}`, screenshotOptions);
       }
 
       // run visual tests

--- a/src/command.js
+++ b/src/command.js
@@ -11,7 +11,8 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
         errorThreshold = params;
       } else if (typeof params === 'object') {
         errorThreshold = params.errorThreshold || 0.0;
-        screenshotOptions = { ...screenshotOptions, ...params };
+          // eslint-disable-next-line prefer-object-spread
+        screenshotOptions = Object.assign({}, defaultScreenshotOptions, params);
       }
       let title = 'actual';
       if (Cypress.env('type') === 'base') {

--- a/src/command.js
+++ b/src/command.js
@@ -11,7 +11,7 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
         errorThreshold = params;
       } else if (typeof params === 'object') {
         errorThreshold = params.errorThreshold || 0.0;
-          // eslint-disable-next-line prefer-object-spread
+        // eslint-disable-next-line prefer-object-spread
         screenshotOptions = Object.assign({}, defaultScreenshotOptions, params);
       }
       let title = 'actual';

--- a/src/command.js
+++ b/src/command.js
@@ -11,7 +11,6 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
         errorThreshold = params;
       } else if (typeof params === 'object') {
         errorThreshold = params.errorThreshold || 0.0;
-        // eslint-disable-next-line prefer-object-spread
         screenshotOptions = Object.assign({}, defaultScreenshotOptions, params);
       }
       let title = 'actual';


### PR DESCRIPTION
The change adds possibility to pass options to `cy.screenshot` call.

The `compareSnapshot` can be called either with number like before, or you can pass an object that contains `cy.screenshot` options.

It also allows to specify default `cy.screenshot` options that are passed by default if no options are provided.
