### PR TITLE
Dont generate base snapshot if already exists

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -18,19 +18,25 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
         title = 'base';
       }
 
+      const options = {
+        fileName: name,
+        specDirectory: Cypress.spec.name,
+      };
+
       // take snapshot
-      if (subject) {
-        cy.get(subject).screenshot(`${name}-${title}`, screenshotOptions);
-      } else {
-        cy.screenshot(`${name}-${title}`, screenshotOptions);
-      }
+      cy.task('checkBaseSnapshot', options).then((results) => {
+        if (Cypress.env('type') === 'base' && results.existsBase) {
+          return;
+        }
+        if (subject) {
+          cy.get(subject).screenshot(`${name}-${title}`, screenshotOptions);
+        } else {
+          cy.screenshot(`${name}-${title}`, screenshotOptions);
+        }
+      });
 
       // run visual tests
       if (Cypress.env('type') === 'actual') {
-        const options = {
-          fileName: name,
-          specDirectory: Cypress.spec.name,
-        };
         cy.task('compareSnapshotsPlugin', options).then((results) => {
           if (results.percentage > errorThreshold) {
             throw new Error(

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -106,8 +106,21 @@ async function compareSnapshotsPlugin(args) {
   };
 }
 
+function checkBaseSnapshot(args) {
+  const base = path.join(
+    SNAPSHOT_DIRECTORY,
+    'base',
+    args.specDirectory,
+    `${args.fileName}-base.png`
+  );
+  return {
+    existsBase: fs.existsSync(base),
+  };
+}
+
 function getCompareSnapshotsPlugin(on) {
   on('task', { compareSnapshotsPlugin });
+  on('task', { checkBaseSnapshot });
 }
 
 module.exports = getCompareSnapshotsPlugin;


### PR DESCRIPTION
Hi, this PR is related to my issue #34

## The problem

I tried to find a good solution to avoid override existing snapshots when running `npm run --env type=base`. I would like to generate base snapshots of the new tests or new test cases only and to avoid specifying my `testFiles` to the `npm run --env type=base` command.

## The solution

Before making a screenshot for a base snapshot, it checks if the snapshot already exists. So if the snapshot exists, the screenshot is not taken, else it is.

So the actual behaviour remains the same, when you run
```
cypress run --env type=base --config screenshotsFolder=cypress/snapshots/base
```

But if you add `trashAssetsBeforeRuns=false` to the command, then base snapshots are not deleted, so only the new ones are generated:
```
cypress run --env type=base --config screenshotsFolder=cypress/snapshots/base,trashAssetsBeforeRuns=false
```
And if you want to update one specific snapshot, you just have to delete it from the `snapshot/base` folder and execute the previous command.

What do you think about it ?

Thanks again for the project ;)