### PR TITLE
Use `failSilently` to throw if `pixelmatch` fails

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -30,6 +30,7 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
         const options = {
           fileName: name,
           specDirectory: Cypress.spec.name,
+          failSilently: Cypress.env('failSilently'),
         };
         cy.task('compareSnapshotsPlugin', options).then((results) => {
           if (results.percentage > errorThreshold) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -98,6 +98,10 @@ async function compareSnapshotsPlugin(args) {
 
     diff.pack().pipe(fs.createWriteStream(options.diffImage));
   } catch (error) {
+    if (!args.failSilently) {
+      throw error;
+    }
+
     console.log(error); // eslint-disable-line no-console
   }
   return {


### PR DESCRIPTION
This PR tries to address https://github.com/mjhea0/cypress-visual-regression/issues/37

It seems `failSilently` wasn't passed to the plugin (am I missing something?). If that is really the case then this should be backwards compatible. 

I don't know if this is the direction you would like to take, let me know and I will update :)