### PR TITLE
Check if snapshot file exists before parsing it

### DIFF
--- a/docker/cypress/integration/main.spec.js
+++ b/docker/cypress/integration/main.spec.js
@@ -5,6 +5,17 @@ describe('Visual Regression Example', () => {
     cy.compareSnapshot('home');
   });
 
+  it("handle missing base snapshot file as a failed spec", () => {
+    cy.visit("/01.html");
+    if (Cypress.env("type") === "actual") {
+      try {
+        cy.compareSnapshotTest("missing").should("be.false");
+      } catch (e) {
+        throw new Error("Missing snapshot file not handled correctly");
+      }
+    };
+  });
+
   it('should display the register page correctly', () => {
     cy.visit('/02.html');
     cy.get('H1').contains('Register');

--- a/docker/cypress/support/commands.js
+++ b/docker/cypress/support/commands.js
@@ -32,7 +32,15 @@ function compareSnapshotTestCommand() {
         failSilently: Cypress.env("failSilently") !== undefined ? Cypress.env("failSilently") : true
       };
       cy.task('compareSnapshotsPlugin', options).then(results => {
-        if (results.percentage > errorThreshold) return false;
+        if (results.error) {
+          console.log(results.error); // eslint-disable-line no-console
+          return false
+        }
+
+        if (results.percentage > errorThreshold) {
+          return false
+        };
+
         return true;
       });
     }

--- a/src/command.js
+++ b/src/command.js
@@ -32,6 +32,10 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
           specDirectory: Cypress.spec.name,
         };
         cy.task('compareSnapshotsPlugin', options).then((results) => {
+          if (results.error) {
+            throw new Error(results.error);
+          }
+
           if (results.percentage > errorThreshold) {
             throw new Error(
               `The "${name}" image is different. Threshold limit exceeded! \nExpected: ${errorThreshold} \nActual: ${results.percentage}`

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -132,7 +132,7 @@ async function compareSnapshotsPlugin(args) {
 
     diff.pack().pipe(fs.createWriteStream(options.diffImage));
   } catch (error) {
-    console.log(error); // eslint-disable-line no-console
+    return { error };
   }
   return {
     mismatchedPixels,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -38,6 +38,11 @@ async function createFolder(folderPath, failSilently) {
 
 async function parseImage(image) {
   return new Promise((resolve, reject) => {
+    if (!fs.existsSync(image)) {
+      reject(new Error(`Snapshot ${image} does not exist.`));
+      return;
+    }
+
     const fd = fs.createReadStream(image);
     /* eslint-disable func-names */
     fd.pipe(new PNG())


### PR DESCRIPTION
This PR address #42, adding a check that a snapshot file does actually exist before trying to load and parse it.