### PR TITLE
Use errorThreshold from global options

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -4,7 +4,7 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
   Cypress.Commands.add(
     'compareSnapshot',
     { prevSubject: 'optional' },
-    (subject, name, params = 0.0) => {
+    (subject, name, params = {}) => {
       const SNAPSHOT_BASE_DIRECTORY = Cypress.env('SNAPSHOT_BASE_DIRECTORY');
       const SNAPSHOT_DIFF_DIRECTORY = Cypress.env('SNAPSHOT_DIFF_DIRECTORY');
 


### PR DESCRIPTION
As described [here](https://github.com/mjhea0/cypress-visual-regression/issues/75), global options are only took in consideration if we pass an empty object as the second argument.

This PR intends to solve this issue passing the empty object as the default value for the `params` parameter.
With this we guarantee that the code bellow will work:
```
compareSnapshotCommand({
  capture: "fullPage",
  errorThreshold: 0.04,
});

cy.compareSnapshot("home"); // use global options errorThreshold (0.04)
cy.compareSnapshot("home", 0.03); // use 0.03 as errorThreshold
cy.compareSnapshot("home"); // use 0.0 as errorThreshold
```