### PR TITLE
Added missing compareSnapshot TS types

### DIFF
--- a/src/command.d.ts
+++ b/src/command.d.ts
@@ -1,12 +1,15 @@
+interface CompareSnapshotOptions {
+  errorThreshold: number;
+}
 
 declare global {
   namespace Cypress {
     interface Chainable {
       compareSnapshot(name: string): void;
       compareSnapshot(name: string, errorThreshold?: number): void;
-      compareSnapshot(name: string, options?: Partial<Cypress.ScreenshotDefaultsOptions> ): void;
+      compareSnapshot(name: string, options?: Partial<Cypress.ScreenshotOptions | CompareSnapshotOptions> ): void;
     }
   }
 }
 
-export default function compareSnapshotCommand(options?: Partial<Cypress.ScreenshotDefaultsOptions>): void;
+export default function compareSnapshotCommand(options?: Partial<Cypress.ScreenshotOptions | CompareSnapshotOptions>): void;


### PR DESCRIPTION
Hi!

I added missing compareSnapshot TS types. Without them you can't use options like `errorThreshold` in your command.ts project file. 