### PR TITLE
enable .d.ts to check Cypress test code

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ import compareSnapshotCommand from 'cypress-visual-regression/dist/command';
 compareSnapshotCommand();
 ```
 
+*cypress/tsconfig.json*
+
+```json:
+{
+  "compilerOptions": {
+    "types": [
+      "cypress",
+      "cypress-visual-regression"
+    ]
+  }
+}
+```
+
 For more info on how to use TypeScript with Cypress, please refer to [this document](https://docs.cypress.io/guides/tooling/typescript-support#Set-up-your-dev-environment).
 
 

--- a/package.json
+++ b/package.json
@@ -48,5 +48,6 @@
     "pixelmatch": "^5.2.1",
     "pngjs": "^6.0.0",
     "sanitize-filename": "^1.6.3"
-  }
+  },
+  "types": "dist/command.d.ts"
 }


### PR DESCRIPTION
My PR specifies .d.ts file for user projects. It enables code completion and type check for TypeScript compiler.

<img width="843" alt="スクリーンショット 2021-12-08 23 40 51" src="https://user-images.githubusercontent.com/564612/145227547-27805d7a-4555-4617-97b8-ab6c7b82b803.png">
