### PR TITLE
Update README.md - method cy.screenshot() should be cy.compareSnapshot()

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ You can target a single HTML element as well:
 cy.get('#my-header').compareSnapshot('just-header')
 ```
 
-You can pass arguments as an object to `cy.screenshot()`, rather than just an error threshold, as well:
+You can pass arguments as an object to `cy.compareSnapshot()`, rather than just an error threshold, as well:
 
 ```js
 it('should display the login page correctly', () => {


### PR DESCRIPTION
I noticed while reading the `README.md` that it mentions `cy.screenshot()`, when it should be using `cy.compareSnapshot()`. This PR fixes it.