### PR TITLE
feat: allow auto-fixing of snapshots when running in regression mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Add support for updating base snapshots on regression mismatch via `visualRegressionUpdateSnapshots`.
+
 ## v5.3.0
 
 - Adjust diff screenshot name according to cypress retry attempt, addresses [#277] (https://github.com/cypress-visual-regression/cypress-visual-regression/pull/277)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ module.exports = defineConfig({
 Pay attention to the `visualRegressionType` option. Use 'base' to generate baseline images, and 'regression' to compare current
 screenshot to the base screenshot
 
+When running in `'regression'` mode, you can enable automatic base snapshot updates on mismatch using `visualRegressionUpdateSnapshots`.
+
+```bash
+CYPRESS_visualRegressionType=regression CYPRESS_visualRegressionUpdateSnapshots=true cypress run --spec 'cypress/e2e/**/*.cy.ts'
+```
+
+You can also set it through Cypress CLI env: `cypress run --env visualRegressionUpdateSnapshots=true`.
+
 In your support file _cypress/support/e2e.js_ add the following:
 
 ```javascript
@@ -111,13 +119,14 @@ module.exports = defineConfig({
 })
 ```
 
-| Variable                      | Default                  | Description                                                                                                                                                  |
-| ----------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| visualRegressionType          | /                        | Either 'regression' or 'base'. Base will override any existing base images with new screenshots. Regression will compare the base to the current screenshot. |
-| visualRegressionBaseDirectory | 'cypress/snapshots/base' | Path to the directory where the base snapshots will be stored.                                                                                               |
-| visualRegressionDiffDirectory | 'cypress/snapshots/diff' | Path to the directory where the generated image differences will be stored.                                                                                  |
-| visualRegressionGenerateDiff  | 'fail'                   | Either 'fail', 'never' or 'always'. Determines if and when image differences are generated.                                                                  |
-| visualRegressionFailSilently  | false                    | Used to decide if any error found in regression should be thrown or returned as part of the result.                                                          |
+| Variable                        | Default                  | Description                                                                                                                                                  |
+| ------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| visualRegressionType            | /                        | Either 'regression' or 'base'. Base will override any existing base images with new screenshots. Regression will compare the base to the current screenshot. |
+| visualRegressionBaseDirectory   | 'cypress/snapshots/base' | Path to the directory where the base snapshots will be stored.                                                                                               |
+| visualRegressionDiffDirectory   | 'cypress/snapshots/diff' | Path to the directory where the generated image differences will be stored.                                                                                  |
+| visualRegressionGenerateDiff    | 'fail'                   | Either 'fail', 'never' or 'always'. Determines if and when image differences are generated.                                                                  |
+| visualRegressionFailSilently    | false                    | Used to decide if any error found in regression should be thrown or returned as part of the result.                                                          |
+| visualRegressionUpdateSnapshots | false                    | When set to true, regression mismatches update existing base snapshots instead of failing. Set using Cypress env values.                                     |
 
 To override different default arguments/options on a global level pass them to the `addCompareSnapshotCommand()` command:
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -34,6 +34,7 @@ export type CypressConfigEnv = {
   visualRegressionDiffDirectory?: string
   visualRegressionGenerateDiff?: DiffOption
   visualRegressionFailSilently?: boolean
+  visualRegressionUpdateSnapshots?: boolean
 }
 
 /** Add custom cypress command to compare image snapshots of an element or the window. */
@@ -109,6 +110,7 @@ function prepareOptions(
     baseDirectory: 'cypress/snapshots/base',
     diffDirectory: 'cypress/snapshots/diff',
     generateDiff: 'fail',
+    updateSnapshots: false,
     spec: Cypress.spec
   }
 
@@ -137,6 +139,10 @@ function prepareOptions(
   }
   if (Cypress.env('visualRegressionFailSilently') !== undefined) {
     options.pluginOptions.failSilently = Cypress.env('visualRegressionFailSilently')
+  }
+  if (Cypress.env('visualRegressionUpdateSnapshots') !== undefined) {
+    const envValue = Cypress.env('visualRegressionUpdateSnapshots')
+    options.updateSnapshots = envValue === true || envValue === 'true' || envValue === 1 || envValue === '1'
   }
 
   // lastly, override values provided through compareSnapshot command


### PR DESCRIPTION
_WIP: Missing testing (e.g. with `yalc`)_

---

## Purpose

Add support for updating base snapshots automatically when a regression run detects a mismatch, so teams can refresh baselines without switching to base mode.

## Approach and changes

Introduced a Cypress env option that, when enabled in regression mode, copies the current screenshot over the base on mismatch instead of failing.

- [x] added `visualRegressionUpdateSnapshots` env option and wired it in the command options
- [x] extended plugin types and comparison flow to copy actual image to base path when the option is on and a regression error occurs
- [x] documented the option in README (env var and table) and added an Unreleased entry in CHANGELOG
- [x] added unit test that uses a temp base dir and asserts the base file is updated and matches the actual screenshot

## Testing instructions

1. Run regression with update mode: `CYPRESS_visualRegressionType=regression CYPRESS_visualRegressionUpdateSnapshots=true cypress run --spec 'cypress/e2e/**/*.cy.ts'` (or equivalent spec).
2. Trigger a deliberate visual change in the app and re-run; confirm the base snapshot is updated and the run passes.