### PR TITLE
chore/improve types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add support for updating base snapshots on regression mismatch via `visualRegressionUpdateSnapshots`.
+- Improve TypeScript support for element snapshots and `compareSnapshot` overwrites.
 - Drop support for Cypress v12, v13
 - Drop support for Node v18, v20
 - Bumps all dependency versions

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,13 +1,26 @@
 // Load type definitions that come with Cypress module
 import type {
   DiffOption,
-  TypeOption,
-  VisualRegressionOptions,
-  VisualRegressionResult,
   PluginCommandOptions,
+  PluginOptions,
+  TypeOption,
   VisualRegressionImages,
-  PluginOptions
+  VisualRegressionOptions,
+  VisualRegressionResult
 } from './plugin'
+
+export type CompareSnapshotSubject = Cypress.JQueryWithSelector | void
+export type CompareSnapshotCommandFn = (
+  subject: CompareSnapshotSubject,
+  name: string,
+  commandOptions?: PluginCommandOptions
+) => Cypress.Chainable<VisualRegressionResult>
+export type CompareSnapshotOverwriteFn = (
+  originalFn: CompareSnapshotCommandFn,
+  subject: CompareSnapshotSubject,
+  name: string,
+  commandOptions?: PluginCommandOptions
+) => Cypress.Chainable<VisualRegressionResult> | void
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -23,6 +36,15 @@ declare global {
        * @param commandOptions - additional screenshot and plugin options to control the visual regression behavior
        */
       compareSnapshot(name: string, commandOptions?: PluginCommandOptions): Chainable<VisualRegressionResult>
+    }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface Commands {
+      /**
+       * Overwrite compareSnapshot as a dual command. Cypress injects the previous subject
+       * as the first argument when compareSnapshot is chained from another command.
+       */
+      overwrite(name: 'compareSnapshot', fn: CompareSnapshotOverwriteFn): void
     }
   }
 }
@@ -42,10 +64,10 @@ function addCompareSnapshotCommand(screenshotOptions?: Partial<Cypress.Screensho
     'compareSnapshot',
     { prevSubject: ['optional', 'element'] },
     function (
-      subject: Cypress.JQueryWithSelector | void,
+      subject: CompareSnapshotSubject,
       name: string,
       commandOptions?: PluginCommandOptions
-    ): Cypress.Chainable {
+    ): Cypress.Chainable<VisualRegressionResult> {
       if (name === undefined || name === '') {
         throw new Error('Snapshot name must be specified')
       }
@@ -159,7 +181,7 @@ function prepareOptions(
 
 /** Take a screenshot and move screenshot to base or actual folder */
 function takeScreenshot(
-  subject: Cypress.JQueryWithSelector | void,
+  subject: CompareSnapshotSubject,
   name: string,
   screenshotOptions: Partial<Cypress.ScreenshotOptions>
 ): Cypress.Chainable {
@@ -182,7 +204,7 @@ function takeScreenshot(
 
 /** Call the plugin to compare snapshot images and generate a diff */
 function compareScreenshots(
-  subject: Cypress.JQueryWithSelector | void,
+  subject: CompareSnapshotSubject,
   options: VisualRegressionOptions
 ): Cypress.Chainable<VisualRegressionResult> {
   const retryAttempt = Cypress.currentRetry
@@ -242,7 +264,7 @@ function compareScreenshots(
 
 /** Call the plugin to update base snapshot images */
 function updateSnapshots(
-  subject: Cypress.JQueryWithSelector | void,
+  subject: CompareSnapshotSubject,
   options: VisualRegressionOptions
 ): Cypress.Chainable<VisualRegressionResult> {
   return cy.task<VisualRegressionResult>('updateSnapshot', options, { log: false }).then((result) => {

--- a/tests/ts/cypress/e2e/spec.cy.ts
+++ b/tests/ts/cypress/e2e/spec.cy.ts
@@ -2,5 +2,6 @@ describe('run cypress-visual-regression in ts project', () => {
   it('should run without errors', () => {
     cy.visit('https://example.cypress.io')
     cy.compareSnapshot('ts')
+    cy.get('h1').compareSnapshot('ts-heading', 0.2)
   })
 })

--- a/tests/ts/cypress/support/e2e.ts
+++ b/tests/ts/cypress/support/e2e.ts
@@ -1,2 +1,19 @@
 import { addCompareSnapshotCommand } from 'cypress-visual-regression/dist/command'
 addCompareSnapshotCommand()
+
+Cypress.Commands.overwrite('compareSnapshot', (originalFn, ...args) => {
+  return originalFn(...args)
+})
+
+Cypress.Commands.overwrite('compareSnapshot', (originalFn, subject, name, commandOptions) => {
+  if (typeof commandOptions === 'number') {
+    return originalFn(subject, name, commandOptions)
+  }
+
+  return originalFn(subject, name, {
+    ...commandOptions,
+    onBeforeScreenshot($el: JQuery) {
+      commandOptions?.onBeforeScreenshot?.($el)
+    }
+  })
+})


### PR DESCRIPTION
## Purpose

Improve TS support for `compareSnapshot` when it is used as an element command or overwritten with `Cypress.Commands.overwrite`.

Previously, TS consumers could call `cy.compareSnapshot(...)`, but common documented usages like `cy.get('h1').compareSnapshot(...)` and `Cypress.Commands.overwrite('compareSnapshot', (originalFn, ...args) => originalFn(...args))` were not typed accurately. This forced downstream projects to use broad type assertions around Cypress/plugin runtime behavior.

## Approach and changes

Added explicit types for the `compareSnapshot` command implementation and `overwrite` API.

- [x] added exported `CompareSnapshotSubject`, `CompareSnapshotCommandFn`, and `CompareSnapshotOverwriteFn` types
- [x] added a `Cypress.Commands.overwrite('compareSnapshot', ...)` overload matching the plugin’s dual-command runtime signature
- [x] tightened the internal command return type to `Cypress.Chainable<VisualRegressionResult>`
- [x] updated the TS fixture to cover:
    - `cy.get('h1').compareSnapshot(...)`
    - the documented `originalFn(...args)` overwrite pattern
    - subject-aware overwrite that forwards screenshot options
